### PR TITLE
Remove Hound configuration file

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-jshint:
-  enabled: true
-  config_file: .jshintrc


### PR DESCRIPTION
The Hound and Codebeat checks have been removed, so we don't need `.hound.yml` any more.