### PR TITLE
Prevent deprecations causing errors

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -140,7 +140,7 @@ export function deprecate(message) {
   try {
     throw new Error(`DEPRECATION: ${message}`);
   } catch (e) {
-    if (process && process.emitWarning) {
+    if (typeof process === 'object' && typeof process.emitWarning === 'function') {
       process.emitWarning(`${message}\n${e.stack}`);
     } else {
       console.warn(`${message}\n${e.stack}`);


### PR DESCRIPTION
In order to work in a browser environment, `typeof` should be used to
check for a global that might not exist. This solves the `Uncaught
ReferenceError: process is not defined` error.

Resolves #140