### PR TITLE
Deprecate ChordJS in favour of ChordSheetJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,27 @@
+# ⚠️ NOTE: ChordJS has been merged into [ChordSheetJS](https://github.com/martijnversluis/ChordSheetJS)
+
+ChordJS will not receive any more updates, although it will remain on NPM. To benefit from new features, please use ChordSheetJS instead.
+
+```bash
+npm install chordjs
+```
+
+or:
+
+```bash
+yarn add chordjs
+```
+
+```javascript
+import Chord from 'chordsheetjs';
+const chord = Chord.parse('Em');
+```
+
+-----
+
 # ChordJS [![Build Status](https://travis-ci.org/martijnversluis/ChordJS.svg?branch=master)](https://travis-ci.org/martijnversluis/ChordJS) [![npm version](https://badge.fury.io/js/chordjs.svg)](https://badge.fury.io/js/chordjs) [![Code Climate](https://codeclimate.com/github/martijnversluis/ChordJS/badges/gpa.svg)](https://codeclimate.com/github/martijnversluis/ChordJS)
 
 A simple JavaScript chord parsing and manipulation tool
-
-## ⚠️ NOTE: These are the V2 docs. The V1 docs are [here](https://github.com/martijnversluis/ChordJS/tree/v1.1.1#readme).
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint:fix": "node_modules/.bin/eslint --fix --ext .js .",
     "build:sources": "babel src --out-dir lib",
     "build": "yarn build:sources",
-    "prepublishOnly": "yarn install && yarn test && yarn build"
+    "prepublishOnly": "yarn install && yarn test && yarn build",
+    "postinstall": "echo \"ChordJS has been merged into ChordSheetJS. ChordJS will not receive updates. See: https://github.com/martijnversluis/ChordJS#readme\""
   },
   "dependencies": {}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,18 @@ import { deprecate } from './functions';
 
 export { parse };
 
+deprecate(`
+ChordJS has been merged into ChordSheetJS.
+ChordJS will not receive any more updates, although it will remain on NPM.
+To benefit from new features, please use ChordSheetJS instead:
+
+    npm install chordjs
+
+or
+
+    yarn add chordjs
+`.substring(1));
+
 export default {
   parse(chordString) {
     deprecate(


### PR DESCRIPTION
# ⚠️ ChordJS has been merged into [ChordSheetJS](https://github.com/martijnversluis/ChordSheetJS)

ChordJS will not receive any more updates, although it will remain on NPM. To benefit from new features, please use ChordSheetJS instead.

```bash
npm install chordjs
```

or:

```bash
yarn add chordjs
```

```javascript
import Chord from 'chordsheetjs';
const chord = Chord.parse('Em');
```